### PR TITLE
Add support for exporting clamped values to SmoothOwenScrambling

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The scripts outputs multiple file:
 * {prefix}_soft.dat: points after optimization where the tree is not binarized
 * {prefix}_init.dat: initial points (after the starting random tree is applied, but before optimization)
 * {prefix}_soft_tree.txt: floating point values stored in the tree
+* {prefix}_clamped_tree.txt: integer values clamped to 0 or 1 from the {prefix}_soft_tree.txt, suitable for use with standard Owen Scramble
 
 where {prefix} is the parameter passed to the script
 

--- a/src/SmoothOwen/SmoothOwen.cpp
+++ b/src/SmoothOwen/SmoothOwen.cpp
@@ -52,19 +52,26 @@ uint32_t SmoothOwenScrambling::NumParamsPerDims() const
     return thetas[0].size();
 }
 
-void SmoothOwenScrambling::Export(const std::string& filename) const
+void SmoothOwenScrambling::Export(const std::string& filename, bool clamped) const
 {
-    std::ofstream out(filename.c_str());
-    out << std::setprecision(20) << std::fixed;
+	std::ofstream out(filename.c_str());
+	out << std::setprecision(20) << std::fixed;
 
-    for (unsigned int i = 0; i < thetas.size(); i++)
-    {
-        for (unsigned int d = 0; d < thetas[i].size(); d++)
-        {
-            out << thetas[i][{d}] << " ";
-        }
-        out << '\n';
-    }
+	for (unsigned int i = 0; i < thetas.size(); i++)
+	{
+		for (unsigned int d = 0; d < thetas[i].size(); d++)
+		{
+			if (clamped)
+			{
+				out << (thetas[i][{d}] > 0.5 ? 1 : 0);
+			}
+			else
+			{
+				out << thetas[i][{d}] << " ";
+			}
+		}
+		out << '\n';
+	}
 }
 
 void SmoothOwenScrambling::ExportGrad(const std::string& filename, const BinaryArray& pts, unsigned int d)

--- a/src/SmoothOwen/SmoothOwen.hpp
+++ b/src/SmoothOwen/SmoothOwen.hpp
@@ -33,7 +33,7 @@ public:
     
     uint32_t NumParamsPerDims() const;
 
-    void Export(const std::string& filename) const;
+    void Export(const std::string& filename, bool clamped) const;
 
     void ExportGrad(const std::string& filename, const BinaryArray& pts, unsigned int dim);
 public: // Easy access to thetas

--- a/src/main/main_gbn.cpp
+++ b/src/main/main_gbn.cpp
@@ -107,5 +107,6 @@ int main(int argc, char** argv)
     WritePts(out_prefix + "_soft.dat", pts);
     WritePts(out_prefix + "_" + std::to_string(Depth + 1) + ".dat", pts);     
 
-    scrambling.Export(out_prefix + "_tree_soft.txt");   
+    scrambling.Export(out_prefix + "_tree_soft.txt", false);
+    scrambling.Export(out_prefix + "_tree_hard.txt", true);
 }

--- a/src/main/main_int.cpp
+++ b/src/main/main_int.cpp
@@ -108,5 +108,6 @@ int main(int argc, char** argv)
     WritePts(out_prefix + "_soft.dat", pts);
     WritePts(out_prefix + "_" + std::to_string(Depth + 1) + ".dat", pts);     
 
-    scrambling.Export(out_prefix + "_tree_soft.txt");   
+    scrambling.Export(out_prefix + "_tree_soft.txt", false);   
+    scrambling.Export(out_prefix + "_tree_clamped.txt", true);
 }

--- a/src/main/main_pcf.cpp
+++ b/src/main/main_pcf.cpp
@@ -111,5 +111,6 @@ int main(int argc, char** argv)
     WritePts(out_prefix + "_soft.dat", pts);
     WritePts(out_prefix + "_" + std::to_string(Depth + 1) + ".dat", pts);     
 
-    scrambling.Export(out_prefix + "_tree_soft.txt");   
+	scrambling.Export(out_prefix + "_tree_soft.txt", false);
+	scrambling.Export(out_prefix + "_tree_clamped.txt", true);
 }

--- a/src/main/main_progressive_gbn.cpp
+++ b/src/main/main_progressive_gbn.cpp
@@ -128,5 +128,6 @@ int main(int argc, char** argv)
     WritePts(out_prefix + "_soft.dat", pts);
     WritePts(out_prefix + "_" + std::to_string(Depth + 1) + ".dat", pts);     
 
-    scrambling.Export(out_prefix + "_tree_soft.txt");   
+	scrambling.Export(out_prefix + "_tree_soft.txt", false);
+	scrambling.Export(out_prefix + "_tree_clamped.txt", true);
 }

--- a/src/main/main_progressive_int.cpp
+++ b/src/main/main_progressive_int.cpp
@@ -131,5 +131,6 @@ int main(int argc, char** argv)
     WritePts(out_prefix + "_soft.dat", pts);
     WritePts(out_prefix + "_" + std::to_string(Depth + 1) + ".dat", pts);     
 
-    scrambling.Export(out_prefix + "_tree_soft.txt");   
+    scrambling.Export(out_prefix + "_tree_soft.txt", false);
+	scrambling.Export(out_prefix + "_tree_clamped.txt", true);
 }

--- a/src/main/main_progressive_w2.cpp
+++ b/src/main/main_progressive_w2.cpp
@@ -123,5 +123,6 @@ int main(int argc, char** argv)
     WritePts(out_prefix + "_soft.dat", pts);
     WritePts(out_prefix + "_" + std::to_string(Depth + 1) + ".dat", pts);     
 
-    scrambling.Export(out_prefix + "_tree_soft.txt");   
+	scrambling.Export(out_prefix + "_tree_soft.txt", false);
+	scrambling.Export(out_prefix + "_tree_clamped.txt", true);
 }

--- a/src/main/main_w2.cpp
+++ b/src/main/main_w2.cpp
@@ -101,5 +101,6 @@ int main(int argc, char** argv)
     WritePts(out_prefix + "_soft.dat", pts);
     WritePts(out_prefix + "_" + std::to_string(Depth + 1) + ".dat", pts);     
 
-    scrambling.Export(out_prefix + "_tree_soft.txt");   
+    scrambling.Export(out_prefix + "_tree_soft.txt", false);
+    scrambling.Export(out_prefix + "_tree_clamped.txt", true);
 }


### PR DESCRIPTION
This PR adds the ability to export clamped values (0 or 1) in the `SmoothOwenScrambling` class. The change introduces a new optional `clamped` parameter to the `Export` method and updates relevant main programs to generate `_tree_clamped.txt` files. The clamped output ensures compatibility with standard Owen Scramble. 
Documentation has been updated to reflect this new functionality.

Please let me know your thoughts on this change and if there are any improvements or adjustments needed.

Thanks.